### PR TITLE
Use official dist file

### DIFF
--- a/bin/update-repo.php
+++ b/bin/update-repo.php
@@ -215,7 +215,7 @@ function pushTags()
   $latestRelease = $releases[0];
   validateRelease($latestRelease);
   
-  if (!updateMasterBranch("$stagingDir/master", $latestRelease->name, $latestRelease->->distball_url)) {
+  if (!updateMasterBranch("$stagingDir/master", $latestRelease->name, $latestRelease->distball_url)) {
     throw new \RuntimeException("failed to update master branch");
   }
   echo "updated master successfully\n";

--- a/bin/update-repo.php
+++ b/bin/update-repo.php
@@ -193,7 +193,7 @@ function pushTags()
     if (!mkdir($tagDir) && !is_dir($tagDir)) {
       throw new \RuntimeException(sprintf('Directory "%s" was not created', $tagDir));
     }
-    $built = buildBranch($version, $release->zipball_url, $tagDir);
+    $built = buildBranch($version, "https://wordpress.org/wordpress-{$version}.zip", $tagDir);
     if (!$built) {
       throw new \RuntimeException("failed to build out $version");
     }
@@ -206,7 +206,7 @@ function pushTags()
   $latestRelease = $releases[0];
   validateRelease($latestRelease);
   
-  if (!updateMasterBranch("$stagingDir/master", $latestRelease->name, $latestRelease->zipball_url)) {
+  if (!updateMasterBranch("$stagingDir/master", $latestRelease->name, "https://wordpress.org/wordpress-{$latestRelease->name}.zip")) {
     throw new \RuntimeException("failed to update master branch");
   }
   echo "updated master successfully\n";

--- a/bin/update-wp-releases.php
+++ b/bin/update-wp-releases.php
@@ -65,9 +65,14 @@ function collectTags()
     ++$page;
   } while (count($pageResults) > 0);
   
-  return array_filter($tags, function ($tag) {
+  $tags = array_filter($tags, function ($tag) {
     return version_compare($tag->name, '4.0', '>=');
   });
+  
+  return array_map(function ($tag) {
+    $tag->distball_url = "https://wordpress.org/wordpress-{$tag->name}.zip";
+    return $tag;
+  }, $tags);
 }
 
 function writeReleaseFile($tags)


### PR DESCRIPTION
This is a proposal to use official dist archive from https://wordpress.org/download/releases/

I'm sure there are better way to do this, but may require [a small refactoring](https://github.com/roots/wordpress/projects/1#card-15625518).

Fix #3 (and prepare https://github.com/roots/wordpress/projects/1#card-15623591)

---
Note that we may also use the "official" git repo `git://core.git.wordpress.org/` ([ref](https://wordpress.org/download/source/)), that said tags don't follow WordPress versioning style, so...