### PR TITLE
Update minimum PHP version to `5.6.20`

### DIFF
--- a/bin/build-branch.php
+++ b/bin/build-branch.php
@@ -59,7 +59,7 @@ function makeComposerPackage($version, $zipURL)
     'type' => 'wordpress-core',
     'version' => $version,
     'require' => [
-      'php' => '>=5.3.2',
+      'php' => '>=5.6.20',
       'roots/wordpress-core-installer' => '>=1.0.0'
     ],
     'dist' => [


### PR DESCRIPTION
> WordPress 5.2 is targeted for release at the end of this month, and with it comes an update to the minimum required version of PHP. WordPress will now require a minimum of PHP 5.6.20.
>
> -- https://wordpress.org/news/2019/04/minimum-php-version-update/