### PR TITLE
Determine minimum PHP version for WordPress core

### DIFF
--- a/bin/build-branch.php
+++ b/bin/build-branch.php
@@ -29,8 +29,20 @@ SOFTWARE.
 EOT;
 }
 
+function minPhpVersionFor(string $version): string
+{
+    $minPhpVersion = '5.6.20';
+    if (version_compare($version, '5.2', '<')) {
+        $minPhpVersion = '5.2.4';
+    }
+
+    return $minPhpVersion;
+}
+
 function makeComposerPackage($version, $zipURL)
 {
+  $minPhpVersion = minPhpVersionFor($version);
+
   return [
     'name' => 'roots/wordpress',
     'description' => 'WordPress is web software you can use to create a beautiful website or blog.',
@@ -59,7 +71,7 @@ function makeComposerPackage($version, $zipURL)
     'type' => 'wordpress-core',
     'version' => $version,
     'require' => [
-      'php' => '>=5.3.2',
+      'php' => ">=${minPhpVersion}",
       'roots/wordpress-core-installer' => '>=1.0.0'
     ],
     'dist' => [


### PR DESCRIPTION
This implementation breaks for non-stable versions, i.e: `beta` and `rc`.
https://github.com/ItinerisLtd/wordpress/blob/1d34138b86fb5500480c97fba159b30afbe2a87d/src/MinPhpVersion.php would be a more robust alternative.
However, it requires introducing `composer` to the build system.

See:
- https://wordpress.org/news/2019/04/minimum-php-version-update/
- http://displaywp.com/wordpress-minimum-php-version/