### PR TITLE
👷 disable workflow schedule

### DIFF
--- a/.github/workflows/update-composer-package.yml
+++ b/.github/workflows/update-composer-package.yml
@@ -2,8 +2,6 @@ name: Update roots/wordpress composer package
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '*/10 * * * *'
 
 jobs:
   update:


### PR DESCRIPTION
this repo is being deprecated in favor of https://github.com/roots/wordpress-packager