### PR TITLE
Add a workflow to keep meta-package versions in sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude for archive generation
+/.git* export-ignore

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -10,19 +10,21 @@ jobs:
     name: Sync
     runs-on: ubuntu-latest
     outputs:
-      tags-matrix: steps.outputs.tags-matrix
-      latest-release: steps.outputs.latest-release
+      tags-matrix: steps.tags-matrix.outputs.tags-matrix
+      latest-release: steps.latest-release.outputs.latest-release
     steps:
       - name: Get upstream package name
         id: package
-        run: echo "::set-output name=upstream::$(jq -r '.require | map_values(select(. == "self.version")) | keys[]' composer.json)"
+        run: echo "::set-output name=package-name::$(jq -r '.require | map_values(select(. == "self.version")) | keys[]' composer.json)"
 
       - name: Generate diff of versions arrays
+        id: tags-matrix
         run: echo TODO
         # Read GitHub API on current & upstream tags and diff
         # Output: tags-matrix
 
       - name: Extract latest release
+        id: latest-release
         run: echo TODO
         # Semver compare to get the new latest
         # Or sort the array out and get the last value

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -1,0 +1,63 @@
+name: Versions
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '*/10 * * * *'
+
+jobs:
+  sync:
+    name: Sync
+    runs-on: ubuntu-latest
+    outputs:
+      tags-matrix: steps.outputs.tags-matrix
+      latest-release: steps.outputs.latest-release
+    steps:
+      - name: Get upstream package name
+        # Read package name in composer.json
+      - name: Generate diff of versions arrays
+        # Read GitHub API on current & upstream tags and diff
+        # Output: tags-matrix
+      - name: Extract latest release
+        # Semver compare to get the new latest
+        # Or sort the array out and get the last value
+        # Output: latest-release
+
+  tags:
+    name: Tags
+    runs-on: ubuntu-latest
+    needs:
+      - sync
+    if: needs.sync.outputs.tags-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.sync.outputs.tags-matrix) }}
+    steps:
+      - name: Create a tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ matrix.tag }}
+          message: ${{ matrix.tag }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs:
+      - sync
+      - tags
+    if: needs.sync.outputs.latest-release
+    steps:
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - name: Create a release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          body: Version ${{ needs.sync.outputs.latest-release }}
+          tag_name: ${{ needs.sync.outputs.latest-release }}

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -14,11 +14,16 @@ jobs:
       latest-release: steps.outputs.latest-release
     steps:
       - name: Get upstream package name
-        # Read package name in composer.json
+        id: package
+        run: echo "::set-output name=upstream::$(jq -r '.require | map_values(select(. == "self.version")) | keys[]' composer.json)"
+
       - name: Generate diff of versions arrays
+        run: echo TODO
         # Read GitHub API on current & upstream tags and diff
         # Output: tags-matrix
+
       - name: Extract latest release
+        run: echo TODO
         # Semver compare to get the new latest
         # Or sort the array out and get the last value
         # Output: latest-release

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -2,6 +2,11 @@ name: Versions
 
 on:
   workflow_dispatch:
+    inputs:
+      dry-run:
+        required: true
+        type: boolean
+        default: true
   # schedule:
   #   - cron: '*/10 * * * *'
 
@@ -10,25 +15,37 @@ jobs:
     name: Sync
     runs-on: ubuntu-latest
     outputs:
-      tags-matrix: steps.tags-matrix.outputs.tags-matrix
-      latest-release: steps.latest-release.outputs.latest-release
+      tags-matrix: steps.tags-matrix.outputs.result
+      latest-release: steps.latest-release.outputs.result
     steps:
       - name: Get upstream package name
         id: package
-        run: echo "::set-output name=package-name::$(jq -r '.require | map_values(select(. == "self.version")) | keys[]' composer.json)"
+        run: echo "::set-output name=package-name::$(jq -r '.require | map_values(select(. == "self.version")) | keys[0]' composer.json)"
 
       - name: Generate diff of versions arrays
         id: tags-matrix
-        run: echo TODO
-        # Read GitHub API on current & upstream tags and diff
-        # Output: tags-matrix
+        uses: actions/github-script@v6
+        env:
+          PACKAGE: ${{ steps.package.outputs.package-name }}
+        with:
+          script: |
+            const { PACKAGE } = process.env
+            const currrentTags = github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            const upstreamTags = github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: PACKAGE.substring(str.indexOf('/') + 1),
+              per_page: 15
+            })
+            return upstreamTags.filter((tag) => !currrentTags.includes(tag))
 
       - name: Extract latest release
         id: latest-release
-        run: echo TODO
-        # Semver compare to get the new latest
-        # Or sort the array out and get the last value
-        # Output: latest-release
+        env:
+          TAGS: ${{ steps.tags-matrix.outputs.result }}
+        run: echo "::set-output name=result::$(jq -r '.[0]' <<< "$TAGS")"
 
   tags:
     name: Tags
@@ -43,6 +60,7 @@ jobs:
     steps:
       - name: Create a tag
         uses: rickstaa/action-create-tag@v1
+        if: ${{ ! inputs.dry-run }}
         with:
           tag: ${{ matrix.tag }}
           message: ${{ matrix.tag }}
@@ -64,6 +82,7 @@ jobs:
 
       - name: Create a release
         uses: softprops/action-gh-release@v1
+        if: ${{ ! inputs.dry-run }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
           body: Version ${{ needs.sync.outputs.latest-release }}


### PR DESCRIPTION
Closes previous attempt https://github.com/roots/wordpress-packager/pull/537

Closes #1 

Added an option to dry-run it for debugging before actual tags submission.